### PR TITLE
Update dataset.py

### DIFF
--- a/jsonstat/dataset.py
+++ b/jsonstat/dataset.py
@@ -262,7 +262,7 @@ class JsonStatDataSet:
             raise JsonStatException('dataset not initialized')
 
         # decoding args
-        idx = self._2idx(*args, **kargs)
+        idx = str(self._2idx(*args, **kargs))
         value = self.__value[idx]
 
         #


### PR DESCRIPTION
self.__value keys are stored as str, therefore line 265 self._2idx return has to be converted to str otherwise it raises a KeyError
could this be a python3 thing?